### PR TITLE
Adding support for quotes in XmlState.Text

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Joris Hermans - http://github.com/jorishermans
 
 With contributions by:
 James Ots - https://github.com/jamesots
+Thomas Gysemans - https://github.com/ThomasGysemans

--- a/example/quotes_example.dart
+++ b/example/quotes_example.dart
@@ -1,0 +1,11 @@
+import 'package:xmlstream/xmlstream.dart';
+
+void main() {
+  print("Making sure that quotes are not ignored when placed within text.");
+
+  var rawText = '<?xml version="1.0" encoding="UTF-8"?><root>This is some "text" and the owner\'s looking for it.</root>';
+
+  var xmlStreamer = new XmlStreamer(rawText);
+
+  xmlStreamer.read().listen((e) => print("listen: $e"));
+}

--- a/lib/xml/xml_event.dart
+++ b/lib/xml/xml_event.dart
@@ -4,8 +4,8 @@ class XmlEvent extends XmlBaseEvent {
   XmlState state;
   String? key;
   String? value;
-  
-  XmlEvent(this.state, {this.key : "", this.value : ""});
-  
+
+  XmlEvent(this.state, {this.key = "", this.value = ""});
+
   String toString() => "$state, [$key] $value";
 }

--- a/lib/xml/xml_streamer.dart
+++ b/lib/xml/xml_streamer.dart
@@ -2,7 +2,7 @@ part of xml_stream;
 
 class XmlStreamer {
   static const EMPTY = '';
-  
+
   Stream<List<int>>? stream;
   // raw xmldata that needs to be parsed
   String? raw;
@@ -13,20 +13,19 @@ class XmlStreamer {
   late String _comment;
 
   String? special_char;
-  
+
   late StreamController<XmlEvent> _controller;
-  
+
   bool _shutdown = false;
-  
-  
+
   XmlStreamer(this.raw, {this.trimSpaces = true});
-  
+
   XmlStreamer.fromStream(this.stream);
-  
+
   Stream<XmlEvent> read() {
     _controller = new StreamController<XmlEvent>();
     XmlEvent event = createAndAddXmlEvent(XmlState.StartDocument);
-  
+
     String? prev;
     if (this.stream == null) {
       var chars_raw = this.raw!.split("");
@@ -50,16 +49,15 @@ class XmlStreamer {
           }
         }
       };
-      controller = stream!.listen(onData,
-          onDone: () {
-            createAndAddXmlEvent(XmlState.EndDocument);
-            _controller.close();
-          });
+      controller = stream!.listen(onData, onDone: () {
+        createAndAddXmlEvent(XmlState.EndDocument);
+        _controller.close();
+      });
     }
 
     return _controller.stream;
   }
-  
+
   XmlEvent _processRawChar(var ch, var prev, XmlEvent event) {
     switch (event.state) {
       case XmlState.CDATA:
@@ -81,7 +79,9 @@ class XmlStreamer {
       default:
         switch (ch) {
           case XmlChar.LT:
-            if (this.trimSpaces) { event.value = event.value!.trim(); }
+            if (this.trimSpaces) {
+              event.value = event.value!.trim();
+            }
             if (event.state != null && event.value!.isNotEmpty) {
               _addElement(event);
             }
@@ -140,11 +140,15 @@ class XmlStreamer {
           case XmlChar.SINGLE_QUOTES:
             if (event.state == XmlState.Attribute) {
               event = _quotes_handling(ch, event);
+            } else if (event.state == XmlState.Text) {
+              event = addCharToValue(event, ch);
             }
             break;
           case XmlChar.DOUBLE_QUOTES:
             if (event.state == XmlState.Attribute) {
               event = _quotes_handling(ch, event);
+            } else if (event.state == XmlState.Text) {
+              event = addCharToValue(event, ch);
             }
             break;
           case XmlChar.NEWLINE:
@@ -171,47 +175,44 @@ class XmlStreamer {
         return event;
     }
   }
-  
+
   XmlEvent _quotes_handling(String ch, XmlEvent event) {
     if (special_char == null) {
       special_char = ch;
     } else if (special_char == ch) {
       _addElement(event);
       event = _createXmlEvent(event.state);
-      
+
       special_char = null;
     }
-    
+
     return event;
   }
-  
+
   XmlEvent _addElement(XmlEvent event) {
-    if (_shouldAdd(event)) { 
-      _controller.add(event); 
+    if (_shouldAdd(event)) {
+      _controller.add(event);
       event.fired = true;
     }
     if (event.state == XmlState.Open) {
       _open_value = event.value;
-    } 
-    
+    }
+
     return event;
   }
-  
+
   bool _shouldAdd(XmlEvent event) {
-    if (event.state == XmlState.Attribute ||
-        event.state == XmlState.CDATA ||
-        event.state == XmlState.Open || 
-        event.state == XmlState.Closed) {
-        if (event.key == "" && event.value == "") {
-          return false;
-        }
-        if (event.fired) {
-          return false;
-        }
+    if (event.state == XmlState.Attribute || event.state == XmlState.CDATA || event.state == XmlState.Open || event.state == XmlState.Closed) {
+      if (event.key == "" && event.value == "") {
+        return false;
+      }
+      if (event.fired) {
+        return false;
+      }
     }
     return true;
   }
-  
+
   XmlEvent addCharToValue(XmlEvent event, String ch) {
     var value = event.value;
     event.value = "$value$ch";
@@ -220,24 +221,27 @@ class XmlStreamer {
 
   XmlEvent createAndAddXmlEvent(XmlState state) {
     XmlEvent event = _createXmlEvent(state);
-      _controller.add(event);
+    _controller.add(event);
     event.fired = true;
     return event;
   }
-  
+
   XmlEvent _createXmlEventAndCheck(XmlEvent event, XmlState state) {
     if (event.fired == false) {
       _addElement(event);
     }
     return _createXmlEvent(state);
   }
-  
+
   XmlEvent _createXmlEvent(XmlState state) {
     XmlEvent event = new XmlEvent(state);
-    event..value=EMPTY
-         ..key=EMPTY;
+    event
+      ..value = EMPTY
+      ..key = EMPTY;
     return event;
   }
-  
-  void shutdown() { _shutdown = true; }
+
+  void shutdown() {
+    _shutdown = true;
+  }
 }

--- a/lib/xml/xml_streamer.dart
+++ b/lib/xml/xml_streamer.dart
@@ -2,7 +2,7 @@ part of xml_stream;
 
 class XmlStreamer {
   static const EMPTY = '';
-
+  
   Stream<List<int>>? stream;
   // raw xmldata that needs to be parsed
   String? raw;
@@ -13,19 +13,20 @@ class XmlStreamer {
   late String _comment;
 
   String? special_char;
-
+  
   late StreamController<XmlEvent> _controller;
-
+  
   bool _shutdown = false;
-
+  
+  
   XmlStreamer(this.raw, {this.trimSpaces = true});
-
+  
   XmlStreamer.fromStream(this.stream);
-
+  
   Stream<XmlEvent> read() {
     _controller = new StreamController<XmlEvent>();
     XmlEvent event = createAndAddXmlEvent(XmlState.StartDocument);
-
+  
     String? prev;
     if (this.stream == null) {
       var chars_raw = this.raw!.split("");
@@ -49,15 +50,16 @@ class XmlStreamer {
           }
         }
       };
-      controller = stream!.listen(onData, onDone: () {
-        createAndAddXmlEvent(XmlState.EndDocument);
-        _controller.close();
-      });
+      controller = stream!.listen(onData,
+          onDone: () {
+            createAndAddXmlEvent(XmlState.EndDocument);
+            _controller.close();
+          });
     }
 
     return _controller.stream;
   }
-
+  
   XmlEvent _processRawChar(var ch, var prev, XmlEvent event) {
     switch (event.state) {
       case XmlState.CDATA:
@@ -79,9 +81,7 @@ class XmlStreamer {
       default:
         switch (ch) {
           case XmlChar.LT:
-            if (this.trimSpaces) {
-              event.value = event.value!.trim();
-            }
+            if (this.trimSpaces) { event.value = event.value!.trim(); }
             if (event.state != null && event.value!.isNotEmpty) {
               _addElement(event);
             }
@@ -175,44 +175,47 @@ class XmlStreamer {
         return event;
     }
   }
-
+  
   XmlEvent _quotes_handling(String ch, XmlEvent event) {
     if (special_char == null) {
       special_char = ch;
     } else if (special_char == ch) {
       _addElement(event);
       event = _createXmlEvent(event.state);
-
+      
       special_char = null;
     }
-
+    
     return event;
   }
-
+  
   XmlEvent _addElement(XmlEvent event) {
-    if (_shouldAdd(event)) {
-      _controller.add(event);
+    if (_shouldAdd(event)) { 
+      _controller.add(event); 
       event.fired = true;
     }
     if (event.state == XmlState.Open) {
       _open_value = event.value;
-    }
-
+    } 
+    
     return event;
   }
-
+  
   bool _shouldAdd(XmlEvent event) {
-    if (event.state == XmlState.Attribute || event.state == XmlState.CDATA || event.state == XmlState.Open || event.state == XmlState.Closed) {
-      if (event.key == "" && event.value == "") {
-        return false;
-      }
-      if (event.fired) {
-        return false;
-      }
+    if (event.state == XmlState.Attribute ||
+        event.state == XmlState.CDATA ||
+        event.state == XmlState.Open || 
+        event.state == XmlState.Closed) {
+        if (event.key == "" && event.value == "") {
+          return false;
+        }
+        if (event.fired) {
+          return false;
+        }
     }
     return true;
   }
-
+  
   XmlEvent addCharToValue(XmlEvent event, String ch) {
     var value = event.value;
     event.value = "$value$ch";
@@ -221,27 +224,24 @@ class XmlStreamer {
 
   XmlEvent createAndAddXmlEvent(XmlState state) {
     XmlEvent event = _createXmlEvent(state);
-    _controller.add(event);
+      _controller.add(event);
     event.fired = true;
     return event;
   }
-
+  
   XmlEvent _createXmlEventAndCheck(XmlEvent event, XmlState state) {
     if (event.fired == false) {
       _addElement(event);
     }
     return _createXmlEvent(state);
   }
-
+  
   XmlEvent _createXmlEvent(XmlState state) {
     XmlEvent event = new XmlEvent(state);
-    event
-      ..value = EMPTY
-      ..key = EMPTY;
+    event..value=EMPTY
+         ..key=EMPTY;
     return event;
   }
-
-  void shutdown() {
-    _shutdown = true;
-  }
+  
+  void shutdown() { _shutdown = true; }
 }

--- a/test/quotes_in_text_test.dart
+++ b/test/quotes_in_text_test.dart
@@ -1,0 +1,20 @@
+import "package:test/test.dart";
+import 'package:xmlstream/xmlstream.dart';
+
+main() {
+  // First tests!
+  var rawText = '<?xml version="1.0" encoding="UTF-8"?><text>"bonjour" is "hello" in French, et "c\'est utile de le savoir" means "it is useful to know it"</text><hello attr="flow">world</hello><text>Did you know that "text" is "texte" in French?</text>';
+
+  var states = [XmlState.StartDocument, XmlState.Top, XmlState.Open, XmlState.Text, XmlState.Closed, XmlState.Open, XmlState.Attribute, XmlState.Text, XmlState.Closed, XmlState.Open, XmlState.Text, XmlState.Closed, XmlState.EndDocument];
+  var values = ["", "", "text", '"bonjour" is "hello" in French, et "c\'est utile de le savoir" means "it is useful to know it"', "text", "hello", "world", "hello", "text", 'Did you know that "text" is "texte" in French?', "text", ""];
+  int count = 0;
+
+  var xmlStreamer = new XmlStreamer(rawText);
+  test('quotes in text', () {
+    xmlStreamer.read().listen((e) {
+      expect(e.state, states[count]);
+      expect(e.value, values[count]);
+      count++;
+    });
+  });
+}


### PR DESCRIPTION
With this update, it is not necessary to escape text using `&quot;` or `&apos;`. It is very useful for packages like `styled_text` (from pub.dev) because escaping these characters is annoying and sometimes creates problems such as the  disappearance of those characters and conflict when dealing with custom tag attributes.